### PR TITLE
Fix notes and warnings for Temporal docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/add/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/add/index.html
@@ -47,7 +47,7 @@ add(<var>duration</var>, <var>options</var>);
 </dl>
 
 <div class="note">
-If any of the <code>years</code>, <code>months</code>, or <code>weeks</code> properties of either of the durations are nonzero, then the <code>relativeTo</code> option (and thus the <var>options</var> object) is <strong>required</strong>.  This is because adding durations with years, months, or weeks requires a point on the calendar to figure out how long they are.
+<p><strong>Note:</strong> If any of the <code>years</code>, <code>months</code>, or <code>weeks</code> properties of either of the durations are nonzero, then the <code>relativeTo</code> option (and thus the <var>options</var> object) is <strong>required</strong>.  This is because adding durations with years, months, or weeks requires a point on the calendar to figure out how long they are.</p>
 </div>
 
 </dd>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/compare/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/compare/index.html
@@ -19,8 +19,8 @@ tags:
 <h2 id="syntax">Syntax</h2>
 
 <pre class="brush: js">
-compare(<var>durationOne</var>, <var>durationTwo</code>);
-compare(<var>durationOne</var>, <var>durationTwo</code>, <var>options</var>);
+compare(durationOne, durationTwo);
+compare(durationOne, durationTwo, options);
 </pre>
 
 <h3 id="parameters">Parameters</h3>
@@ -47,7 +47,7 @@ Either a <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object
 </dl>
 
 <div class="note">
-If any of the <code>years</code>, <code>months</code>, or <code>weeks</code> properties of either of the durations are nonzero, then the <code>relativeTo</code> option (and thus the <var>options</var> object) is <strong>required</strong>.  This is because comparing durations with years, months, or weeks requires a point on the calendar to figure out how long they are.
+<p><strong>Note:</strong> If any of the <code>years</code>, <code>months</code>, or <code>weeks</code> properties of either of the durations are nonzero, then the <code>relativeTo</code> option (and thus the <var>options</var> object) is <strong>required</strong>.  This is because comparing durations with years, months, or weeks requires a point on the calendar to figure out how long they are.</p>
 </div>
 
 </dd>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/from/index.html
@@ -25,7 +25,7 @@ from(<var>duration</var>)
 <dd>A representation of the desired duration.  If the value is another <code>{{jsxref('Temporal.Duration','Temporal.Duration')}}</code> object, a new <code>Temporal.Duration</code> object representing the same length of time is returned. If the value is any other object, a <code>{{jsxref('Temporal.Duration','Temporal.Duration')}}</code> will be constructed from the values of any <code>years</code>, <code>months</code>, <code>weeks</code>, <code>days</code>, <code>hours</code>, <code>minutes</code>, <code>seconds</code>, <code>milliseconds</code>, <code>microseconds</code>, and <code>nanoseconds</code> properties that are present. Any missing values are assumed to be <code>0</code>.</p>
 
 <div class="warning">
-<p>All non-zero values must have the same sign, and must not be infinite. Otherwise, the function will throw a <code>RangeError</code>.</p>
+<p><strong>Warning:</strong> All non-zero values must have the same sign, and must not be infinite. Otherwise, the function will throw a <code>RangeError</code>.</p>
 </div>
 
 <p>Any non-object value will be converted to a string, which is expected to be in ISO 8601 format.  This method understands strings where weeks and other units are combined, and strings with a single sign character at the start, which are extensions to the ISO 8601 standard described in ISO 8601-2. For example, <code>P3W1D</code> is understood to mean three weeks and one day, <code>-P1Y1M</code> is a negative duration of one year and one month, and <code>+P1Y1M</code> is one year and one month. If no sign character is present, then the sign is assumed to be positive.</p>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/index.html
@@ -18,7 +18,7 @@ tags:
 <p>When printed, a <code>Temporal.Duration</code> object produces a string conforming to the ISO 8601 notation for durations.  Briefly, the ISO 8601 notation consists of a <code>P</code> character, followed by years, months, weeks, and days, followed by a <code>T</code> character, followed by hours, minutes, and seconds with a decimal part, each with a single-letter suffix that indicates the unit. Any zero components may be omitted. For more detailed information, see the ISO 8601 standard or <a href="https://en.wikipedia.org/wiki/ISO_8601#Durations">the Wikipedia page</a>.</p>
 
 <div class="warning">
-<p><strong>NOTE:</strong> According to the ISO 8601-1 standard, weeks are not allowed to appear together with any other units, and durations can only be positive, in string notation. As extensions to the standard, ISO 8601-2 allows a sign character at the start of the string, and allows combining weeks with other units, in string notation. If you intend to use strings such as <code>P3W1D</code>, <code>+P1M</code>, or <code>-PT2H</code>, this may cause interoperability problems with legacy codebases.</p>
+<p><strong>Warning:</strong> According to the ISO 8601-1 standard, weeks are not allowed to appear together with any other units, and durations can only be positive, in string notation. As extensions to the standard, ISO 8601-2 allows a sign character at the start of the string, and allows combining weeks with other units, in string notation. If you intend to use strings such as <code>P3W1D</code>, <code>+P1M</code>, or <code>-PT2H</code>, this may cause interoperability problems with legacy codebases.</p>
 </div>
 
 <h2>Constructor</h2>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/subtract/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/subtract/index.html
@@ -47,7 +47,7 @@ subtract(<var>duration</var>, <var>options</var>)
 </dl>
 
 <div class="note">
-If any of the <code>years</code>, <code>months</code>, or <code>weeks</code> properties of either of the durations are nonzero, then the <code>relativeTo</code> option (and thus the <var>options</var> object) is <strong>required</strong>.  This is because comparing durations with years, months, or weeks requires a point on the calendar to figure out how long they are.
+<p><strong>Note:</strong> If any of the <code>years</code>, <code>months</code>, or <code>weeks</code> properties of either of the durations are nonzero, then the <code>relativeTo</code> option (and thus the <var>options</var> object) is <strong>required</strong>.  This is because comparing durations with years, months, or weeks requires a point on the calendar to figure out how long they are.</p>
 </div>
 
 </dd>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/tojson/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/tojson/index.html
@@ -15,7 +15,7 @@ tags:
 The reverse operation, recovering a <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object from a string, is accomplished by using <code>{{jsxref('Temporal/Duration/from','Temporal.Duration.from()')}}</code>, but that method cannot be called automatically by <code>{{jsxref('JSON.parse','JSON.parse()')}}</code>. If you need to rebuild a <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object from a JSON string, then you need to know the names of the keys that should be interpreted as <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> properties. In that case, you can build a custom "reviver" function for your use case.
 </p>
 <div class="warning">
-<p><strong>NOTE:</strong> If any of <code>duration.milliseconds</code>, <code>duration.microseconds</code>, or <code>duration.nanoseconds</code> are over 999, then deserializing from the result of <code>duration.toJSON()</code> will yield an equal but different object.</p>
+<p><strong>Warning:</strong> If any of <code>duration.milliseconds</code>, <code>duration.microseconds</code>, or <code>duration.nanoseconds</code> are over 999, then deserializing from the result of <code>duration.toJSON()</code> will yield an equal but different object.</p>
 </div>
 
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/tolocalestring/index.html
@@ -13,7 +13,7 @@ tags:
 <p class="summary"><span class="seoSummary">The <strong><code>toLocaleString()</code></strong> method returns a human-readable, language-sensitive representation of the <code>{{jsxref('Temporal.Duration','Temporal.Duration')}}</code> value.</span>  This method overrides {{jsxref('Object/toLocaleString','Object.prototype.toLocaleString()')}}.</p>
 
 <div class="warning">
-<p>This method requires that your JavaScript environment supports <code>Intl.DurationFormat</code>. If <code>`Intl.DurationFormat`</code> is not available, then the output of this method is the same as that of <code>{{jsxref('Temporal/Duration/toString','Temporal.Duration.toString()')}}</code>, and the <code>locales</code> and <code>options</code> arguments are ignored.</p>
+<p><strong>Warning:</strong> This method requires that your JavaScript environment supports <code>Intl.DurationFormat</code>. If <code>`Intl.DurationFormat`</code> is not available, then the output of this method is the same as that of <code>{{jsxref('Temporal/Duration/toString','Temporal.Duration.toString()')}}</code>, and the <code>locales</code> and <code>options</code> arguments are ignored.</p>
 </div>
 
 <h2 id="syntax">Syntax</h2>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/tostring/index.html
@@ -36,10 +36,10 @@ toString(<var>options</var>)
 <li><code>'nanosecond'</code></li>
 </ul>
 <div class="note">
-<p>If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
+<p><strong>Note:</strong> If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
 </div>
 <div class="warning">
-<p><strong>NOTE:</strong> If any of <code>duration.milliseconds</code>, <code>duration.microseconds</code>, or <code>duration.nanoseconds</code> are over 999, then deserializing from the result of <code>duration.toString()</code> will yield an equal but different object.</p>
+<p><strong>Warning:</strong> If any of <code>duration.milliseconds</code>, <code>duration.microseconds</code>, or <code>duration.nanoseconds</code> are over 999, then deserializing from the result of <code>duration.toString()</code> will yield an equal but different object.</p>
 </div>
 </dd>
 <dt><code>roundingMode</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/total/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/total/index.html
@@ -49,7 +49,7 @@ total(<var>options</var>)
 <dd>
 <p>The starting point to use when converting between years, months, weeks, and days, expressed as a <code>{{jsxref('Temporal.PlainDateTime','Temporal.PlainDateTime')}}</code> object, or else a value convertible to one.</p>
 <div class="warning">
-<strong>NOTE:</strong> If <code>unit</code> is <code>'years'</code>, <code>'months'</code>, or <code>'weeks'</code>, the <code>relativeTo</code> option is <strong>required</strong>.
+<p><strong>Warning:</strong> If <code>unit</code> is <code>'years'</code>, <code>'months'</code>, or <code>'weeks'</code>, the <code>relativeTo</code> option is <strong>required</strong>.
 </div>
 </dd>
 </dl>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/instant/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/instant/tolocalestring/index.html
@@ -69,7 +69,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				</ul>
 
 				<div class="notecard note">
-					<p><code>dateStyle</code> can be used with <code>timeStyle</code>, but
+					<p><strong>Note:</strong> <code>dateStyle</code> can be used with <code>timeStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -86,7 +86,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 			</dd>
 			<dd>
 				<div class="notecard note">
-					<p><code>timeStyle</code> can be used with <code>dateStyle</code>, but
+					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/instant/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/instant/tostring/index.html
@@ -38,7 +38,7 @@ toString(<var>options</var>)
 <li><code>'nanosecond'</code></li>
 </ul>
 <div class="note">
-<p>If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
+<p><strong>Note:</strong> If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
 </div>
 </dd>
 <dt><code>roundingMode</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/erayear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/erayear/index.html
@@ -23,7 +23,7 @@ date.eraYear
 
 <p>An integer representing the year of the era containing the year, or <code>undefined</code> in calendar systems that do not use eras.</p>
 <div class="note">
-<p>Unlike <code>{{jsxref('Temporal.PlainDate/year','year')}}</code>, <code>eraYear</code> may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.</p>
+<p><strong>Note:</strong> Unlike <code>{{jsxref('Temporal.PlainDate/year','year')}}</code>, <code>eraYear</code> may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.</p>
 </div>
 
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/from/index.html
@@ -48,7 +48,7 @@ from(<var>date</var>, <var>options</var>)
 <dd>Out-of-range values will cause the function to throw a <code>RangeError</code>.</dd>
 </dl>
 <div class="note">
-<p>If <var>date</var> is a string, the <code>overflow</code> property's value is ignored.</p>
+<p><strong>Note:</strong> If <var>date</var> is a string, the <code>overflow</code> property's value is ignored.</p>
 </div>
 </dd>
 </dl>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/since/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/since/index.html
@@ -15,15 +15,15 @@ tags:
 
 <p class="summary"><span class="seoSummary">The <strong><code>since()</code></strong> method computes the elapsed time between the date represented by <code>plainDate</code> and another date in the past, optionally rounds it, and returns it as a <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object.</span>  If the second date is later than the first, then the resulting duration will be negative.  This method is similar to <code>{{jsxref('Temporal.PlainDate/until','Temporal.PlainDate.until()')}}</code>, but reversed.</p>
 <div class="warning">
-<p>Computing the difference between dates in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates using the method <code>{{jsxref('Temporal.PlainDate/withCalendar','withCalendar()')}}</code>.</p>
+<p><strong>Warning:</strong> Computing the difference between dates in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates using the method <code>{{jsxref('Temporal.PlainDate/withCalendar','withCalendar()')}}</code>.</p>
 </div>
 
 
 <h2 id="syntax">Syntax</h2>
 
 <pre class="brush: js">
-since(<var>otherDate</code>)
-since(<var>otherDate</code>, <var>options</var>)
+since(otherDate)
+since(otherDate, options)
 </pre>
 
 <h3 id="parameters">Parameters</h3>
@@ -47,7 +47,7 @@ since(<var>otherDate</code>, <var>options</var>)
 <p>The <code>largestUnit</code> option controls how the resulting duration is expressed. A value of <code>'auto'</code> means to match the value of <code>smallestUnit</code>.</p>
 <p>The returned <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object will not have any nonzero fields that are larger than the unit in <code>largestUnit</code>. A difference of one year and two months will become 14 months when <code>largestUnit</code> is <code>'months'</code>, for example. However, a difference of one month will still be one month even if <code>largestUnit</code> is <code>'years'</code>.</p>
 <div class="note">
-<p>Unlike some other Temporal types, hours and lower are not allowed for either <code>largestUnit</code> or <code>smallestUnit</code>, because the data model of <code>Temporal.PlainDate</code> doesn't have that accuracy.
+<p><strong>Note:</strong> Unlike some other Temporal types, hours and lower are not allowed for either <code>largestUnit</code> or <code>smallestUnit</code>, because the data model of <code>Temporal.PlainDate</code> doesn't have that accuracy.
 </p>
 </div>
 </dd>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/tolocalestring/index.html
@@ -71,7 +71,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				</ul>
 
 				<div class="notecard note">
-					<p><code>dateStyle</code> can be used with <code>timeStyle</code>, but
+					<p><strong>Note:</strong> <code>dateStyle</code> can be used with <code>timeStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -88,7 +88,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 			</dd>
 			<dd>
 				<div class="notecard note">
-					<p><code>timeStyle</code> can be used with <code>dateStyle</code>, but
+					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -125,7 +125,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				such as "<code>Asia/Shanghai</code>", "<code>Asia/Kolkata</code>",
 				"<code>America/New_York</code>".
 				<div class="note">
-				Unlike in <code>{{jsxref('Temporal.Instant/toLocaleString','Temporal.Instant.toLocaleString()')}}</code>, the <code>timeZone</code> property has no effect, because <code>{{jsxref('Temporal.PlainDate','Temporal.PlainDate')}}</code> carries no time zone information and is just a date.
+				<p><strong>Note:</strong> Unlike in <code>{{jsxref('Temporal.Instant/toLocaleString','Temporal.Instant.toLocaleString()')}}</code>, the <code>timeZone</code> property has no effect, because <code>{{jsxref('Temporal.PlainDate','Temporal.PlainDate')}}</code> carries no time zone information and is just a date.</p>
 				</div>
 				</dd>
 			<dt><code>hour12</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/tostring/index.html
@@ -27,7 +27,7 @@ toString(<var>options</var>)
 <dt><code>calendarName</code></dt>
 <dd><p>Whether to show the calendar annotation in the return value. Valid values are <code>"auto"</code>, <code>"always"</code>, and <code>"never"</code>. The default is <code>"auto"</code>.</p>
 <div class="note">
-<p>Normally, a calendar annotation is shown when the <code>PlainDate</code>'s calendar is not the ISO 8601 calendar. By setting the <code>calendarName</code> option to <code>"always"</code> or <code>"never"</code>, this can be overridden to always or never show the annotation, respectively.</p>
+<p><strong>Note:</strong> Normally, a calendar annotation is shown when the <code>PlainDate</code>'s calendar is not the ISO 8601 calendar. By setting the <code>calendarName</code> option to <code>"always"</code> or <code>"never"</code>, this can be overridden to always or never show the annotation, respectively.</p>
 </div>
 </dd>
 </dl>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/until/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/until/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p class="summary"><span class="seoSummary">The <strong><code>until()</code></strong> method computes the elapsed time from the date represented by <code>plainDate</code> until another date, optionally rounds it, and returns it as a <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object.</span>  If the second date is earlier than the first, then the resulting duration will be negative.  This method is similar to <code>{{jsxref('Temporal.PlainDate/since','Temporal.PlainDate.since()')}}</code>, but reversed.</p>
 <div class="warning">
-<p>Computing the difference between dates in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates using the method <code>{{jsxref('Temporal.PlainDate/withCalendar','withCalendar()')}}</code>.</p>
+<p><strong>Warning:</strong> Computing the difference between dates in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates using the method <code>{{jsxref('Temporal.PlainDate/withCalendar','withCalendar()')}}</code>.</p>
 </div>
 
 
@@ -47,7 +47,7 @@ until(<var>otherDate</var>, <var>options</var>)
 <p>The <code>largestUnit</code> option controls how the resulting duration is expressed. A value of <code>'auto'</code> means to match the value of <code>smallestUnit</code>.</p>
 <p>The returned <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object will not have any nonzero fields that are larger than the unit in <code>largestUnit</code>. A difference of one year and two months will become 14 months when <code>largestUnit</code> is <code>'months'</code>, for example. However, a difference of one month will still be one month even if <code>largestUnit</code> is <code>'years'</code>.</p>
 <div class="note">
-<p>Unlike some other Temporal types, hours and lower are not allowed for either <code>largestUnit</code> or <code>smallestUnit</code>, because the data model of <code>Temporal.PlainDate</code> doesn't have that accuracy.
+<p><strong>Note:</strong> Unlike some other Temporal types, hours and lower are not allowed for either <code>largestUnit</code> or <code>smallestUnit</code>, because the data model of <code>Temporal.PlainDate</code> doesn't have that accuracy.
 </p>
 </div>
 </dd>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/with/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/with/index.html
@@ -25,7 +25,7 @@ with(<var>newValues</var>, <var>options</var>)
 <dt><code><var>newValues</var></code></dt>
 <dd>An object containing some or all of the properties accepted by <code>{{jsxref('Temporal/PlainDate/from','Temporal.PlainDate.from()')}}</code>.
 <div class="note">
-<strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>.  See the methods <code>{{jsxref('Temporal/PlainDate/withCalendar','withCalendar()')}}</code> and <code>{{jsxref('Temporal/PlainDate/toZonedDateTime','toZonedDateTime()')}}</code>.</p>
+<p><strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>.  See the methods <code>{{jsxref('Temporal/PlainDate/withCalendar','withCalendar()')}}</code> and <code>{{jsxref('Temporal/PlainDate/toZonedDateTime','toZonedDateTime()')}}</code>.</p>
 </div>
 </dd>
 <dt><code><var>options</var></code> {{optional_inline}}</dt>
@@ -59,4 +59,3 @@ date.with({ day: 1 }); // => 2006-01-01
 const nextMonthDate = date.add({ months: 1 });
 nextMonthDate.with({ day: nextMonthDate.daysInMonth }); // => 2006-02-28
 </pre>
-

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/year/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/year/index.html
@@ -23,7 +23,7 @@ date.year
 
 <p>A signed integer representing the number of years relative to a calendar-specific anchor date.</p>
 <div class="note">
-<p>For calendars that use eras, the anchor is usually aligned with the latest era so that <code>eraYear === year</code> for all dates in that era.  However, some calendars (like Japanese) may use a different anchor.</p>
+<p><strong>Note:</strong> For calendars that use eras, the anchor is usually aligned with the latest era so that <code>eraYear === year</code> for all dates in that era.  However, some calendars (like Japanese) may use a different anchor.</p>
 </div>
 
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/erayear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/erayear/index.html
@@ -23,7 +23,7 @@ datetime.eraYear
 
 <p>An integer representing the year of the era containing the year, or <code>undefined</code> in calendar systems that do not use eras.</p>
 <div class="note">
-<p>Unlike <code>{{jsxref('Temporal.PlainDateTime/year','year')}}</code>, <code>eraYear</code> may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.</p>
+<p><strong>Note:</strong> Unlike <code>{{jsxref('Temporal.PlainDateTime/year','year')}}</code>, <code>eraYear</code> may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.</p>
 </div>
 
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/from/index.html
@@ -48,10 +48,10 @@ from(<var>dateTime</var>, <var>options</var>)
 <dd>Out-of-range values will cause the function to throw a <code>RangeError</code>.</dd>
 </dl>
 <div class="note">
-<p>If <var>dateTime</var> is a string, the <code>overflow</code> property's value is ignored.</p>
+<p><strong>Note:</strong> If <var>dateTime</var> is a string, the <code>overflow</code> property's value is ignored.</p>
 </div>
 <div class="warning">
-<strong>NOTE:</strong> Although Temporal does not deal with leap seconds, times coming from other software may have a <code>second</code> value of <code>60</code>. In the default <code>constrain</code> mode, this will be converted to <code>59</code>. In <code>reject</code> mode, the constructor will throw, so if you have to interoperate with times that may contain leap seconds, don't use <code>reject</code>. However, if parsing an ISO 8601 string with a seconds component of <code>:60</code>, then it will always result in a <code>second</code> value of <code>59</code>, in accordance with POSIX.
+<p><strong>Warning:</strong>  Although Temporal does not deal with leap seconds, times coming from other software may have a <code>second</code> value of <code>60</code>. In the default <code>constrain</code> mode, this will be converted to <code>59</code>. In <code>reject</code> mode, the constructor will throw, so if you have to interoperate with times that may contain leap seconds, don't use <code>reject</code>. However, if parsing an ISO 8601 string with a seconds component of <code>:60</code>, then it will always result in a <code>second</code> value of <code>59</code>, in accordance with POSIX.</p>
 </div></dd>
 </dl>
 </dd>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/since/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/since/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p class="summary"><span class="seoSummary">The <strong><code>since()</code></strong> method computes the elapsed time between the date and time represented by <var>dateTime</var> and another date and time in the past, optionally rounds it, and returns it as a <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object.</span>  If the second date and time is later than the first, then the resulting duration will be negative.  This method is similar to <code>{{jsxref('Temporal.PlainDateTime/until','Temporal.PlainDateTime.until()')}}</code>, but reversed.</p>
 <div class="warning">
-<p>Computing the difference between dates and times in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates and times using the method <code>{{jsxref('Temporal.PlainDateTime/withCalendar','withCalendar()')}}</code>.</p>
+<p><strong>Warning:</strong> Computing the difference between dates and times in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates and times using the method <code>{{jsxref('Temporal.PlainDateTime/withCalendar','withCalendar()')}}</code>.</p>
 </div>
 
 
@@ -53,7 +53,7 @@ since(<var>otherDateTime</var>, <var>options</var>)
 <p>The <code>largestUnit</code> option controls how the resulting duration is expressed. A value of <code>'auto'</code> means <code>'days'</code> unless the value of <code>smallestUnit</code> is <code>'years'</code>, <code>'months'</code>, or <code>'weeks'</code>, in which case <code>'auto'</code> means to match the value of <code>smallestUnit</code>.</p>
 <p>The returned <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object will not have any nonzero fields that are larger than the unit in <code>largestUnit</code>. A difference of one year and two months will become 14 months when <code>largestUnit</code> is <code>'months'</code>, for example. However, a difference of one month will still be one month even if <code>largestUnit</code> is <code>'years'</code>.</p>
 <div class="warning">
-Take care when using <code>'milliseconds'</code>, <code>'microseconds'</code>, or <code>'nanoseconds'</code> as the largest unit. For some durations, the resulting value may overflow <code>{{jsxref('Number/MAX_SAFE_INTEGER','Number.MAX_SAFE_INTEGER')}}</code> and lose precision in its least significant digit(s). Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.
+<p><strong>Warning:</strong> Take care when using <code>'milliseconds'</code>, <code>'microseconds'</code>, or <code>'nanoseconds'</code> as the largest unit. For some durations, the resulting value may overflow <code>{{jsxref('Number/MAX_SAFE_INTEGER','Number.MAX_SAFE_INTEGER')}}</code> and lose precision in its least significant digit(s). Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.</p>
 </div>
 </dd>
 <dt><code>smallestUnit</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/tolocalestring/index.html
@@ -71,7 +71,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				</ul>
 
 				<div class="notecard note">
-					<p><code>dateStyle</code> can be used with <code>timeStyle</code>, but
+					<p><strong>Note:</strong> <code>dateStyle</code> can be used with <code>timeStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -88,7 +88,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 			</dd>
 			<dd>
 				<div class="notecard note">
-					<p><code>timeStyle</code> can be used with <code>dateStyle</code>, but
+					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -125,7 +125,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				such as "<code>Asia/Shanghai</code>", "<code>Asia/Kolkata</code>",
 				"<code>America/New_York</code>".
 				<div class="note">
-				Unlike in <code>{{jsxref('Temporal.Instant/toLocaleString','Temporal.Instant.toLocaleString()')}}</code>, the <code>timeZone</code> property has no effect, because <code>{{jsxref('Temporal.PlainDateTime','Temporal.PlainDateTime')}}</code> carries no time zone information.
+				<p><strong>Note:</strong> Unlike in <code>{{jsxref('Temporal.Instant/toLocaleString','Temporal.Instant.toLocaleString()')}}</code>, the <code>timeZone</code> property has no effect, because <code>{{jsxref('Temporal.PlainDateTime','Temporal.PlainDateTime')}}</code> carries no time zone information.</p>
 				</div>
 				</dd>
 			<dt><code>hour12</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/tostring/index.html
@@ -27,7 +27,7 @@ toString(<var>options</var>)
 <dt><code>calendarName</code></dt>
 <dd><p>Whether to show the calendar annotation in the return value. Valid values are <code>"auto"</code>, <code>"always"</code>, and <code>"never"</code>. The default is <code>"auto"</code>.</p>
 <div class="note">
-<p>Normally, a calendar annotation is shown when the <code>PlainDateTime</code>'s calendar is not the ISO 8601 calendar. By setting the <code>calendarName</code> option to <code>"always"</code> or <code>"never"</code>, this can be overridden to always or never show the annotation, respectively.</p>
+<p><strong>Note:</strong> Normally, a calendar annotation is shown when the <code>PlainDateTime</code>'s calendar is not the ISO 8601 calendar. By setting the <code>calendarName</code> option to <code>"always"</code> or <code>"never"</code>, this can be overridden to always or never show the annotation, respectively.</p>
 </div>
 </dd>
 <dt><code>fractionalSecondDigits</code></dt>
@@ -42,7 +42,7 @@ toString(<var>options</var>)
 <li><code>'nanosecond'</code></li>
 </ul>
 <div class="note">
-<p>If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
+<p><strong>Note:</strong> If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
 </div>
 </dd>
 <dt><code>roundingMode</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/until/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/until/index.html
@@ -15,7 +15,7 @@ tags:
 
 <p class="summary"><span class="seoSummary">The <strong><code>until()</code></strong> method computes the elapsed time from the date and time represented by <code><var>dateTime</var></code> until another date and time, optionally rounds it, and returns it as a <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object.</span>  If the second date and time is earlier than the first, then the resulting duration will be negative.  This method is similar to <code>{{jsxref('Temporal.PlainDateTime/since','Temporal.PlainDateTime.since()')}}</code>, but reversed.</p>
 <div class="warning">
-<p>Computing the difference between dates and times in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates and times using the method <code>{{jsxref('Temporal.PlainDateTime/withCalendar','withCalendar()')}}</code>.</p>
+<p><strong>Warning:</strong> Computing the difference between dates and times in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates and times using the method <code>{{jsxref('Temporal.PlainDateTime/withCalendar','withCalendar()')}}</code>.</p>
 </div>
 
 
@@ -53,7 +53,7 @@ until(<var>otherDateTime</var>, <var>options</var>)
 <p>The <code>largestUnit</code> option controls how the resulting duration is expressed. A value of <code>'auto'</code> means <code>'days'</code> unless the value of <code>smallestUnit</code> is <code>'years'</code>, <code>'months'</code>, or <code>'weeks'</code>, in which case <code>'auto'</code> means to match the value of <code>smallestUnit</code>.</p>
 <p>The returned <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object will not have any nonzero fields that are larger than the unit in <code>largestUnit</code>. A difference of one year and two months will become 14 months when <code>largestUnit</code> is <code>'months'</code>, for example. However, a difference of one month will still be one month even if <code>largestUnit</code> is <code>'years'</code>.</p>
 <div class="warning">
-Take care when using <code>'milliseconds'</code>, <code>'microseconds'</code>, or <code>'nanoseconds'</code> as the largest unit. For some durations, the resulting value may overflow <code>{{jsxref('Number/MAX_SAFE_INTEGER','Number.MAX_SAFE_INTEGER')}}</code> and lose precision in its least significant digit(s). Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.
+<p><strong>Warning:</strong> Take care when using <code>'milliseconds'</code>, <code>'microseconds'</code>, or <code>'nanoseconds'</code> as the largest unit. For some durations, the resulting value may overflow <code>{{jsxref('Number/MAX_SAFE_INTEGER','Number.MAX_SAFE_INTEGER')}}</code> and lose precision in its least significant digit(s). Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.</p>
 </div>
 </dd>
 <dt><code>smallestUnit</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/with/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/with/index.html
@@ -25,7 +25,7 @@ with(<var>newValues</var>, <var>options</var>)
 <dt><code><var>newValues</var></code></dt>
 <dd>An object containing some or all of the properties accepted by <code>{{jsxref('Temporal/PlainDateTime/from','Temporal.PlainDateTime.from()')}}</code>.
 <div class="note">
-<strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>.  See the methods <code>{{jsxref('Temporal/PlainDateTime/withCalendar','withCalendar()')}}</code> and <code>{{jsxref('Temporal/PlainDateTime/toZonedDateTime','toZonedDateTime()')}}</code>.</p>
+<p><strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>.  See the methods <code>{{jsxref('Temporal/PlainDateTime/withCalendar','withCalendar()')}}</code> and <code>{{jsxref('Temporal/PlainDateTime/toZonedDateTime','toZonedDateTime()')}}</code>.</p>
 </div>
 </dd>
 <dt><code><var>options</var></code> {{optional_inline}}</dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/year/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/year/index.html
@@ -23,7 +23,7 @@ datetime.year
 
 <p>A signed integer representing the number of years relative to a calendar-specific anchor date.</p>
 <div class="note">
-<p>For calendars that use eras, the anchor is usually aligned with the latest era so that <code>eraYear === year</code> for all dates in that era.  However, some calendars (like Japanese) may use a different anchor.</p>
+<p><strong>Note:</strong> For calendars that use eras, the anchor is usually aligned with the latest era so that <code>eraYear === year</code> for all dates in that era.  However, some calendars (like Japanese) may use a different anchor.</p>
 </div>
 
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainmonthday/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainmonthday/tolocalestring/index.html
@@ -72,7 +72,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				</ul>
 
 				<div class="notecard note">
-					<p><code>dateStyle</code> can be used with <code>timeStyle</code>, but
+					<p><strong>Note:</strong> <code>dateStyle</code> can be used with <code>timeStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -89,7 +89,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 			</dd>
 			<dd>
 				<div class="notecard note">
-					<p><code>timeStyle</code> can be used with <code>dateStyle</code>, but
+					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/from/index.html
@@ -39,14 +39,14 @@ from(<var>time</var>, <var>options</var>)
 <dd>Out-of-range values will cause the function to throw a <code>RangeError</code>.</dd>
 </dl>
 <div class="note">
-<p>If the <var>time</var> value is a string, <code>overflow</code> is ignored.</p>
+<p><strong>Note:</strong> If the <var>time</var> value is a string, <code>overflow</code> is ignored.</p>
 </div>
 </dd>
 </dl>
 </dd>
 </dl>
 <div class="warning">
-<strong>NOTE:</strong> Although Temporal does not deal with leap seconds, times coming from other software may have a <code>second</code> value of <code>60</code>. In the default <code>constrain</code> mode, this will be converted to <code>59</code>. In <code>reject</code> mode, the constructor will throw, so if you have to interoperate with times that may contain leap seconds, don't use <code>reject</code>. However, if parsing an ISO 8601 string with a seconds component of <code>:60</code>, then it will always result in a <code>second</code> value of <code>59</code>, in accordance with POSIX.
+<p><strong>Warning:</strong> Although Temporal does not deal with leap seconds, times coming from other software may have a <code>second</code> value of <code>60</code>. In the default <code>constrain</code> mode, this will be converted to <code>59</code>. In <code>reject</code> mode, the constructor will throw, so if you have to interoperate with times that may contain leap seconds, don't use <code>reject</code>. However, if parsing an ISO 8601 string with a seconds component of <code>:60</code>, then it will always result in a <code>second</code> value of <code>59</code>, in accordance with POSIX.
 </div>
 
 <h3 id="return-value">Return value</h3>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/tolocalestring/index.html
@@ -71,7 +71,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				</ul>
 
 				<div class="notecard note">
-					<p><code>dateStyle</code> can be used with <code>timeStyle</code>, but
+					<p><strong>Note:</strong> <code>dateStyle</code> can be used with <code>timeStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -88,7 +88,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 			</dd>
 			<dd>
 				<div class="notecard note">
-					<p><code>timeStyle</code> can be used with <code>dateStyle</code>, but
+					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -125,7 +125,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				such as "<code>Asia/Shanghai</code>", "<code>Asia/Kolkata</code>",
 				"<code>America/New_York</code>".
 				<div class="note">
-				Unlike in <code>{{jsxref('Temporal.Instant/toLocaleString','Temporal.Instant.toLocaleString()')}}</code>, the <code>timeZone</code> property has no effect, because <code>{{jsxref('Temporal.PlainTime','Temporal.PlainTime')}}</code> carries no time zone information and is just a wall-clock time.
+				<p><strong>Note:</strong> Unlike in <code>{{jsxref('Temporal.Instant/toLocaleString','Temporal.Instant.toLocaleString()')}}</code>, the <code>timeZone</code> property has no effect, because <code>{{jsxref('Temporal.PlainTime','Temporal.PlainTime')}}</code> carries no time zone information and is just a wall-clock time.</p>
 				</div>
 				</dd>
 			<dt><code>hour12</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/tostring/index.html
@@ -36,7 +36,7 @@ toString(<var>options</var>)
 <li><code>'nanosecond'</code></li>
 </ul>
 <div class="note">
-<p>If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
+<p><strong>Note:</strong> If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
 </div>
 </dd>
 <dt><code>roundingMode</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/with/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/with/index.html
@@ -25,7 +25,7 @@ with(<var>newValues</var>, <var>options</var>)
 <dt><code><var>newValues</var></code></dt>
 <dd>An object containing some or all of the properties accepted by <code>{{jsxref('Temporal/PlainTime/from','Temporal.PlainTime.from()')}}</code>.
 <div class="note">
-<strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>.  See the methods <code>{{jsxref('Temporal/PlainTime/toPlainDateTime','toPlainDateTime()')}}</code> and <code>{{jsxref('Temporal/PlainTime/toZonedDateTime','toZonedDateTime()')}}</code>.</p>
+<p><strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>.  See the methods <code>{{jsxref('Temporal/PlainTime/toPlainDateTime','toPlainDateTime()')}}</code> and <code>{{jsxref('Temporal/PlainTime/toZonedDateTime','toZonedDateTime()')}}</code>.</p>
 </div>
 </dd>
 <dt><code><var>options</var></code> {{optional_inline}}</dt>
@@ -62,4 +62,3 @@ time.with({
   nanosecond: 0
 }); // => 19:00:00
 </pre>
-

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/add/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/add/index.html
@@ -43,7 +43,7 @@ add(<var>duration</var>, <var>options</var>)
 <dd>Out-of-range values will cause the function to throw a <code>RangeError</code>.</dd>
 </dl>
 <div class="note">
-<strong>Note:</strong> The <code>overflow</code> option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous. However, <code>overflow</code> may have an effect in calendars where years can be different numbers of months.</p>
+<p><strong>Note:</strong> The <code>overflow</code> option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous. However, <code>overflow</code> may have an effect in calendars where years can be different numbers of months.</p>
 </div>
 </dd>
 </dl>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/equals/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/equals/index.html
@@ -36,7 +36,7 @@ equals(<var>other</var>)
 
 <p>A boolean <code>true</code> if <code>PlainYearMonth</code> and <code><var>other</var></code> are equal; otherwise, <code>false</code>. If you also need to know the order in which the two months occur when they are not equal, use <code>{{jsxref('Temporal/PlainYearMonth/compare','Temporal.PlainYearMonth.compare()')}}</code> instead.</p>
 <div class="note">
-<strong>Note:</strong> this function will always return <code>false</code> if the two <code>{{jsxref('Temporal.PlainYearMonth','Temporal.PlainYearMonth')}}</code> objects have different {{jsxref('Temporal.PlainYearMonth/calendar','calendar')}}</code>  properties, even if the actual years and months are equal.
+<p><strong>Note:</strong> This function will always return <code>false</code> if the two <code>{{jsxref('Temporal.PlainYearMonth','Temporal.PlainYearMonth')}}</code> objects have different {{jsxref('Temporal.PlainYearMonth/calendar','calendar')}} properties, even if the actual years and months are equal.</p>
 </div>
 
 <h2 id="examples">Examples</h2>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/erayear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/erayear/index.html
@@ -23,7 +23,7 @@ date.eraYear
 
 <p>An integer representing the year of the era containing the year, or <code>undefined</code> in calendar systems that do not use eras.</p>
 <div class="note">
-<p>Unlike <code>{{jsxref('Temporal.PlainYearMonth/year','year')}}</code>, <code>eraYear</code> may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.</p>
+<p><strong>Note:</strong> Unlike <code>{{jsxref('Temporal.PlainYearMonth/year','year')}}</code>, <code>eraYear</code> may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.</p>
 </div>
 
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/since/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/since/index.html
@@ -20,8 +20,8 @@ tags:
 <h2 id="syntax">Syntax</h2>
 
 <pre class="brush: js">
-since(<var>otherYearMonth</code>)
-since(<var>otherYearMonth</code>, <var>options</var>)
+since(otherYearMonth)
+since(otherYearMonth, options)
 </pre>
 
 <h3 id="parameters">Parameters</h3>
@@ -43,7 +43,7 @@ since(<var>otherYearMonth</code>, <var>options</var>)
 <p>The <code>largestUnit</code> option controls how the resulting duration is expressed. A value of <code>'auto'</code> means <code>'years'</code>.</p>
 <p>The returned <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object will not have any nonzero fields that are larger than the unit in <code>largestUnit</code>. A difference of one year and two months will become 14 months when <code>largestUnit</code> is <code>'months'</code>, for example. However, a difference of one month will still be one month even if <code>largestUnit</code> is <code>'years'</code>.</p>
 <div class="note">
-<p>Unlike other Temporal types, weeks and lower are not allowed for either <code>largestUnit</code> or <code>smallestUnit</code>, because the data model of <code>Temporal.PlainYearMonth</code> doesn't have that accuracy.
+<p><strong>Note:</strong> Unlike other Temporal types, weeks and lower are not allowed for either <code>largestUnit</code> or <code>smallestUnit</code>, because the data model of <code>Temporal.PlainYearMonth</code> doesn't have that accuracy.
 If you need to calculate the difference between two YearMonths in days, convert them to <code>{{jsxref('Temporal.PlainDate','Temporal.PlainDate')}}</code> objects and use <code>{{jsxref('Temporal.PlainDate/until','Temporal.PlainDate.until()')}}</code> instead.
 </p>
 </div>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/subtract/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/subtract/index.html
@@ -43,7 +43,7 @@ subtract(<var>duration</var>, <var>options</var>)
 <dd>Out-of-range values will cause the function to throw a <code>RangeError</code>.</dd>
 </dl>
 <div class="note">
-<strong>Note:</strong> The <code>overflow</code> option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous. However, <code>overflow</code> may have an effect in calendars where years can be different numbers of months.</p>
+<p><strong>Note:</strong> The <code>overflow</code> option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous. However, <code>overflow</code> may have an effect in calendars where years can be different numbers of months.</p>
 </div>
 </dd>
 </dl>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/tolocalestring/index.html
@@ -72,7 +72,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				</ul>
 
 				<div class="notecard note">
-					<p><code>dateStyle</code> can be used with <code>timeStyle</code>, but
+					<p><strong>Note:</strong> <code>dateStyle</code> can be used with <code>timeStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -89,7 +89,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 			</dd>
 			<dd>
 				<div class="notecard note">
-					<p><code>timeStyle</code> can be used with <code>dateStyle</code>, but
+					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/tostring/index.html
@@ -32,7 +32,7 @@ toString(<var>options</var>)
 <dt><code>calendarName</code></dt>
 <dd><p>Whether to show the calendar annotation in the return value. Valid values are <code>"auto"</code>, <code>"always"</code>, and <code>"never"</code>. The default is <code>"auto"</code>.</p>
 <div class="note">
-<p>Normally, a calendar annotation is shown when the <code>PlainYearMonth</code>'s calendar is not the ISO 8601 calendar. By setting the <code>calendarName</code> option to <code>"always"</code> or <code>"never"</code>, this can be overridden to always or never show the annotation, respectively.</p>
+<p><strong>Note:</strong> Normally, a calendar annotation is shown when the <code>PlainYearMonth</code>'s calendar is not the ISO 8601 calendar. By setting the <code>calendarName</code> option to <code>"always"</code> or <code>"never"</code>, this can be overridden to always or never show the annotation, respectively.</p>
 </div>
 </dd>
 </dl>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/until/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/until/index.html
@@ -42,7 +42,7 @@ until(<var>otherYearMonth</var>, <var>options</var>)
 <p>The <code>largestUnit</code> option controls how the resulting duration is expressed. A value of <code>'auto'</code> means <code>'years'</code>.</p>
 <p>The returned <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object will not have any nonzero fields that are larger than the unit in <code>largestUnit</code>. A difference of one year and two months will become 14 months when <code>largestUnit</code> is <code>'months'</code>, for example. However, a difference of one month will still be one month even if <code>largestUnit</code> is <code>'years'</code>.</p>
 <div class="note">
-<p>Unlike other Temporal types, weeks and lower are not allowed for either <code>largestUnit</code> or <code>smallestUnit</code>, because the data model of <code>Temporal.PlainYearMonth</code> doesn't have that accuracy.
+<p><strong>Note:</strong> Unlike other Temporal types, weeks and lower are not allowed for either <code>largestUnit</code> or <code>smallestUnit</code>, because the data model of <code>Temporal.PlainYearMonth</code> doesn't have that accuracy.
 If you need to calculate the difference between two <code>PlainYearMonth</code> objects in days, convert them to <code>{{jsxref('Temporal.PlainDate','Temporal.PlainDate')}}</code> objects and use <code>{{jsxref('Temporal.PlainDate/until','Temporal.PlainDate.until()')}}</code> instead.
 </p>
 </div>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/with/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/with/index.html
@@ -30,7 +30,7 @@ with(<var>newValues</var>, <var>options</var>)
 <dt><code><var>newValues</var></code></dt>
 <dd>An object containing some or all of the properties accepted by <code>{{jsxref('Temporal/PlainYearMonth/from','Temporal.PlainYearMonth.from()')}}</code>.
 <div class="note">
-<strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>. It is not possible to convert a <code>{{jsxref('Temporal.PlainYearMonth','Temporal.PlainYearMonth')}}</code> to another calendar system without knowing the day of the month.</p>
+<p><strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>. It is not possible to convert a <code>{{jsxref('Temporal.PlainYearMonth','Temporal.PlainYearMonth')}}</code> to another calendar system without knowing the day of the month.</p>
 </div>
 </dd>
 <dt><code><var>options</var></code> {{optional_inline}}</dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/erayear/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/erayear/index.html
@@ -23,7 +23,7 @@ datetime.eraYear
 
 <p>An integer representing the year of the era containing the year, or <code>undefined</code> in calendar systems that do not use eras.</p>
 <div class="note">
-<p>Unlike <code>{{jsxref('Temporal.ZonedDateTime/year','year')}}</code>, <code>eraYear</code> may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.</p>
+<p><strong>Note:</strong> Unlike <code>{{jsxref('Temporal.ZonedDateTime/year','year')}}</code>, <code>eraYear</code> may decrease as time proceeds because some eras (like the BCE era in the Gregorian calendar) count years backwards.</p>
 </div>
 
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/from/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/from/index.html
@@ -56,11 +56,11 @@ from(<var>dateTime</var>, <var>options</var>)
 </ul>
 
 <div class="note">
-<p>If <var>dateTime</var> is a string, the <code>overflow</code> property's value is ignored.</p>
+<p><strong>Note:</strong> If <var>dateTime</var> is a string, the <code>overflow</code> property's value is ignored.</p>
 </div>
 
 <div class="warning">
-<strong>NOTE:</strong> Although Temporal does not deal with leap seconds, times coming from other software may have a <code>second</code> value of <code>60</code>. In the default <code>constrain</code> mode, this will be converted to <code>59</code>. In <code>reject</code> mode, the constructor will throw, so if you have to interoperate with times that may contain leap seconds, don't use <code>reject</code>. However, if parsing an ISO 8601 string with a seconds component of <code>:60</code>, then it will always result in a <code>second</code> value of <code>59</code>, in accordance with POSIX.
+<p><strong>Warning:</strong> Although Temporal does not deal with leap seconds, times coming from other software may have a <code>second</code> value of <code>60</code>. In the default <code>constrain</code> mode, this will be converted to <code>59</code>. In <code>reject</code> mode, the constructor will throw, so if you have to interoperate with times that may contain leap seconds, don't use <code>reject</code>. However, if parsing an ISO 8601 string with a seconds component of <code>:60</code>, then it will always result in a <code>second</code> value of <code>59</code>, in accordance with POSIX.
 </div>
 
 </dd>
@@ -76,8 +76,9 @@ from(<var>dateTime</var>, <var>options</var>)
 <p>When interoperating with existing code or services, <code>'compatible'</code> disambiguation matches the behavior of legacy {{jsxref('Date','Date')}} as well as libraries like moment.js, Luxon, and date-fns. This mode also matches the behavior of cross-platform standards like RFC 5545 (iCalendar).</p>
 
 <div class="note">
-<p><code>disambiguation</code> is only used if there is no offset in the input, or if the offset is ignored by using the <code>offset</code> option as described above. If the offset in the input is used, then there is no ambiguity and the <code>disambiguation</code> option is ignored.</p></dd>
+<p><strong>Note:</strong> <code>disambiguation</code> is only used if there is no offset in the input, or if the offset is ignored by using the <code>offset</code> option as described above. If the offset in the input is used, then there is no ambiguity and the <code>disambiguation</code> option is ignored.</p>
 </div>
+</dd>
 
 <dt><code>offset</code></dt>
 <dd><p>How to interpret a provided time zone offset (e.g., <code>-02:00</code>) if it conflicts with the provided time zone (e.g., <code>America/Sao_Paulo</code>).  Allowed values are:</p>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/hoursinday/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/hoursinday/index.html
@@ -12,7 +12,7 @@ tags:
 <p class="summary"><span class="seoSummary">The <strong><code>hoursInDay</code></strong> read-only property gives the number of real-world hours between the start of the current day (usually midnight) to the start of the next calendar day in the same time zone.</span>  Normally days will be 24 hours long, but on days where there are DST (Daylight Saving Time) changes or other time zone transitions, this property may return <code>23</code> or <code>25</code>.  In rare cases, other integers or even non-integer values may be returned; e.g., when time zone definitions change by less than one hour.</p>
 
 <div class="note">
-<p>Note that transitions that skip entire days (like the 2011 change of <code>Pacific/Apia</code> to the opposite side of the International Date Line) will return <code>24</code>, because there are 24 real-world hours between one day's midnight and the next day's midnight.</p>
+<p><strong>Note:</strong> Note that transitions that skip entire days (like the 2011 change of <code>Pacific/Apia</code> to the opposite side of the International Date Line) will return <code>24</code>, because there are 24 real-world hours between one day's midnight and the next day's midnight.</p>
 </div>
 
 <h2 id="syntax">Syntax</h2>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/since/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/since/index.html
@@ -25,7 +25,7 @@ tags:
 </ul>
 
 <div class="warning">
-<p>Computing the difference between dates and times in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates and times using the method <code>{{jsxref('Temporal.ZonedDateTime/withCalendar','.withCalendar()')}}</code>.</p>
+<p><strong>Warning:</strong> Computing the difference between dates and times in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates and times using the method <code>{{jsxref('Temporal.ZonedDateTime/withCalendar','.withCalendar()')}}</code>.</p>
 </div>
 
 
@@ -63,7 +63,7 @@ since(<var>otherZonedDateTime</var>, <var>options</var>)
 <p>The <code>largestUnit</code> option controls how the resulting duration is expressed. A value of <code>'auto'</code> means <code>'hours'</code> unless the value of <code>smallestUnit</code> is <code>'years'</code>, <code>'months'</code>, <code>'weeks'</code>, or <code>'days'</code>, in which case <code>'auto'</code> means to match the value of <code>smallestUnit</code>.</p>
 <p>The returned <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object will not have any nonzero fields that are larger than the unit in <code>largestUnit</code>. A difference of one year and two months will become 14 months when <code>largestUnit</code> is <code>'months'</code>, for example. However, a difference of one month will still be one month even if <code>largestUnit</code> is <code>'years'</code>.</p>
 <div class="warning">
-Take care when using <code>'milliseconds'</code>, <code>'microseconds'</code>, or <code>'nanoseconds'</code> as the largest unit. For some durations, the resulting value may overflow <code>{{jsxref('Number/MAX_SAFE_INTEGER','Number.MAX_SAFE_INTEGER')}}</code> and lose precision in its least significant digit(s). Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.
+<p><strong>Warning:</strong> Take care when using <code>'milliseconds'</code>, <code>'microseconds'</code>, or <code>'nanoseconds'</code> as the largest unit. For some durations, the resulting value may overflow <code>{{jsxref('Number/MAX_SAFE_INTEGER','Number.MAX_SAFE_INTEGER')}}</code> and lose precision in its least significant digit(s). Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.</p>
 </div>
 </dd>
 <dt><code>smallestUnit</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/subtract/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/subtract/index.html
@@ -62,7 +62,7 @@ subtract(<var>duration</var>, <var>options</var>)
 <dd>Out-of-range values will cause the function to throw a <code>RangeError</code>.</dd>
 </dl>
 <div class="note">
-<strong>Note:</strong> The <code>overflow</code> option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous. However, <code>overflow</code> may have an effect in calendars where years can be different numbers of months.</p>
+<p><strong>Note:</strong> The <code>overflow</code> option has no effect in the default ISO calendar, because a year is always 12 months and therefore not ambiguous. However, <code>overflow</code> may have an effect in calendars where years can be different numbers of months.</p>
 </div>
 </dd>
 </dl>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/timezone/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/timezone/index.html
@@ -29,7 +29,7 @@ datetime.timeZone
 
 <p>An object representing the time zone of the zoned date and time.  This will depend on what kind of time zone information was used to construct the <code>{{jsxref('Temporal.ZonedDateTime','Temporal.ZonedDateTime')}}</code> object itself.  In most cases, it will be a  <code>{{jsxref('Temporal.TimeZone','Temporal.TimeZone')}}</code> object, but it could possibly be a plain object containing time zone information.</p>
 
-<div class="note"><p>Developers are <strong>strongly</strong> encouraged to make sure they construct the zoned date and time using a <code>{{jsxref('Temporal.TimeZone','Temporal.TimeZone')}}</code> object, or a value that is converted to one at construction time.</p></div>
+<div class="note"><p><strong>Note:</strong> Developers are <strong>strongly</strong> encouraged to make sure they construct the zoned date and time using a <code>{{jsxref('Temporal.TimeZone','Temporal.TimeZone')}}</code> object, or a value that is converted to one at construction time.</p></div>
 
 <h2 id="examples">Examples</h2>
 

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/tolocalestring/index.html
@@ -71,7 +71,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				</ul>
 
 				<div class="notecard note">
-					<p><code>dateStyle</code> can be used with <code>timeStyle</code>, but
+					<p><strong>Note:</strong> <code>dateStyle</code> can be used with <code>timeStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/tostring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/tostring/index.html
@@ -31,7 +31,7 @@ toString(<var>options</var>)
 <dt><code>calendarName</code></dt>
 <dd><p>Whether to show the calendar annotation in the return value. Valid values are <code>'auto'</code>, <code>'always'</code>, and <code>'never'</code>. The default is <code>'auto'</code>.</p>
 <div class="note">
-<p>Normally, a calendar annotation is shown when the <code>ZonedDateTime</code>'s calendar is not the ISO 8601 calendar. By setting the <code>calendarName</code> option to <code>'always'</code> or <code>'never'</code>, this can be overridden to always or never show the annotation, respectively.</p>
+<p><strong>Note:</strong> Normally, a calendar annotation is shown when the <code>ZonedDateTime</code>'s calendar is not the ISO 8601 calendar. By setting the <code>calendarName</code> option to <code>'always'</code> or <code>'never'</code>, this can be overridden to always or never show the annotation, respectively.</p>
 </div>
 </dd>
 <dt><code>fractionalSecondDigits</code></dt>
@@ -46,7 +46,7 @@ toString(<var>options</var>)
 <li><code>'nanosecond'</code></li>
 </ul>
 <div class="note">
-<p>If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
+<p><strong>Note:</strong> If <code>smallestUnit</code> is defined, it overrides the value of <code>fractionalSecondDigits</code>.</p>
 </div>
 </dd>
 <dt><code>roundingMode</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/until/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/until/index.html
@@ -25,7 +25,7 @@ tags:
 </ul>
 
 <div class="warning">
-<p>Computing the difference between dates and times in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates and times using the method <code>{{jsxref('Temporal.ZonedDateTime/withCalendar','.withCalendar()')}}</code>.</p>
+<p><strong>Warning:</strong> Computing the difference between dates and times in different calendar systems is not supported.  If you need to do this, choose the calendar in which the computation takes place by converting one of the dates and times using the method <code>{{jsxref('Temporal.ZonedDateTime/withCalendar','.withCalendar()')}}</code>.</p>
 </div>
 
 
@@ -63,7 +63,7 @@ until(<var>otherZonedDateTime</var>, <var>options</var>)
 <p>The <code>largestUnit</code> option controls how the resulting duration is expressed. A value of <code>'auto'</code> means <code>'hours'</code> unless the value of <code>smallestUnit</code> is <code>'years'</code>, <code>'months'</code>, <code>'weeks'</code>, or <code>'days'</code>, in which case <code>'auto'</code> means to match the value of <code>smallestUnit</code>.</p>
 <p>The returned <code>{{jsxref('Temporal/Duration','Temporal.Duration')}}</code> object will not have any nonzero fields that are larger than the unit in <code>largestUnit</code>. A difference of one year and two months will become 14 months when <code>largestUnit</code> is <code>'months'</code>, for example. However, a difference of one month will still be one month even if <code>largestUnit</code> is <code>'years'</code>.</p>
 <div class="warning">
-Take care when using <code>'milliseconds'</code>, <code>'microseconds'</code>, or <code>'nanoseconds'</code> as the largest unit. For some durations, the resulting value may overflow <code>{{jsxref('Number/MAX_SAFE_INTEGER','Number.MAX_SAFE_INTEGER')}}</code> and lose precision in its least significant digit(s). Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.
+<p><strong>Warning:</strong> Take care when using <code>'milliseconds'</code>, <code>'microseconds'</code>, or <code>'nanoseconds'</code> as the largest unit. For some durations, the resulting value may overflow <code>{{jsxref('Number/MAX_SAFE_INTEGER','Number.MAX_SAFE_INTEGER')}}</code> and lose precision in its least significant digit(s). Nanoseconds values will overflow and lose precision after about 104 days. Microseconds can fit about 285 years without losing precision, and milliseconds can handle about 285,000 years without losing precision.</p>
 </div>
 </dd>
 <dt><code>smallestUnit</code></dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/with/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/with/index.html
@@ -25,7 +25,7 @@ with(<var>newValues</var>, <var>options</var>)
 <dt><code><var>newValues</var></code></dt>
 <dd>An object containing some of the properties accepted by <code>{{jsxref('Temporal/ZonedDateTime/from','Temporal.ZonedDateTime.from()')}}</code>.
 <div class="note">
-<strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>.  See the methods <code>{{jsxref('Temporal/ZonedDateTime/withCalendar','withCalendar()')}}</code> and <code>{{jsxref('Temporal/ZonedDateTime/withTimeZone','withTimeZone()')}}</code>.</p>
+<p><strong>Note:</strong> <code>calendar</code> and <code>timeZone</code> properties are not allowed on <var>newValues</var>.  See the methods <code>{{jsxref('Temporal/ZonedDateTime/withCalendar','withCalendar()')}}</code> and <code>{{jsxref('Temporal/ZonedDateTime/withTimeZone','withTimeZone()')}}</code>.</p>
 </div>
 </dd>
 <dt><code><var>options</var></code> {{optional_inline}}</dt>
@@ -50,8 +50,10 @@ with(<var>newValues</var>, <var>options</var>)
 <p>When interoperating with existing code or services, <code>'compatible'</code> disambiguation matches the behavior of legacy {{jsxref('Date','Date')}} as well as libraries like moment.js, Luxon, and date-fns. This mode also matches the behavior of cross-platform standards like RFC 5545 (iCalendar).</p>
 
 <div class="note">
-<p><code>disambiguation</code> is only used if there is no offset in the input, or if the offset is ignored by using the <code>offset</code> option as described above. If the offset in the input is used, then there is no ambiguity and the <code>disambiguation</code> option is ignored.</p></dd>
+<p><strong>Note:</strong> <code>disambiguation</code> is only used if there is no offset in the input, or if the offset is ignored by using the <code>offset</code> option as described above. If the offset in the input is used, then there is no ambiguity and the <code>disambiguation</code> option is ignored.</p>
 </div>
+</dd>
+
 
 <dt><code>offset</code></dt>
 <dd><p>How to interpret a provided time zone offset (e.g., <code>-02:00</code>) if it conflicts with the provided time zone (e.g., <code>America/Sao_Paulo</code>).  Allowed values are:

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/year/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/year/index.html
@@ -23,7 +23,7 @@ datetime.year
 
 <p>A signed integer representing the number of years relative to a calendar-specific anchor date.</p>
 <div class="note">
-<p>For calendars that use eras, the anchor is usually aligned with the latest era so that <code>eraYear === year</code> for all dates in that era.  However, some calendars (like Japanese) may use a different anchor.</p>
+<p><strong>Note:</strong> For calendars that use eras, the anchor is usually aligned with the latest era so that <code>eraYear === year</code> for all dates in that era.  However, some calendars (like Japanese) may use a different anchor.</p>
 </div>
 
 


### PR DESCRIPTION
Trying to convert the Temporal docs to Markdown, the converter complains about, and refuses to convert, some notes and warnings:

- div.note (40)
- div.warning (19)
- div.notecard.note (7)

That's because the converter expects notes and warnings to have a particular internal structure:

`<p><strong>Note:</strong>...` for notes
`<p><strong>Warning:</strong>...` for warnings

This PR attempts to fix that. I've checked the converter output after this change and the problems are no longer reported.

I fixed a couple of other formatting problems that came up (in a couple of places I've removed all internal markup from code blocks, which is in general what we want to do on MDN).
