### PR TITLE
Fix dl elements in Temporal

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/temporal/duration/round/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/duration/round/index.html
@@ -46,19 +46,23 @@ round(<var>options</var>)
 </ul>
 <p>The <code>largestUnit</code> value determines the largest unit allowed in the result. It  causes units larger than <code>largestUnit</code> to be converted into smaller units, and units smaller than <code>largestUnit</code> to be converted into larger units as much as possible. For example, with <code>largestUnit: 'minutes'</code>, a duration of 1 hour and 125 seconds will be converted into a duration of 62 minutes and 5 seconds.</p>
 <p>A <code>largestUnit</code> value of <code>'auto'</code> means that <code>largestUnit</code> will use largest nonzero unit in the duration that is larger than <code>smallestUnit</code>. For example, in a duration of 3 days and 12 hours, <code>largestUnit: 'auto'</code> would mean the same as <code>largestUnit: 'days'</code>.</p>
+<div class="warning">
+<p><strong>Warning:</strong> At least one of <code>largestUnit</code> and <code>smallestUnit</code> is <strong>required</strong>.</p>
+</div>
 </dd>
 <dt><code>smallestUnit</code></dt>
-<dd><p>A string defining the unit of time to which to round.  Valid values are the same as for <code>largestUnit</code>, with two exceptions: there is no <code>'auto'</code> value, and the default value is <code>'nanoseconds'</code> (which means no rounding is performed).</p></dd>
+<dd><p>A string defining the unit of time to which to round.  Valid values are the same as for <code>largestUnit</code>, with two exceptions: there is no <code>'auto'</code> value, and the default value is <code>'nanoseconds'</code> (which means no rounding is performed).</p>
 <div class="warning">
-<strong>NOTE:</strong> At least one of <code>largestUnit</code> and <code>smallestUnit</code> is <strong>required</strong>.
+<p><strong>Warning:</strong> At least one of <code>largestUnit</code> and <code>smallestUnit</code> is <strong>required</strong>.</p>
 </div>
+</dd>
 <dt><code>relativeTo</code></dt>
 <dd>
 <p>The starting point to use when converting between years, months, weeks, and days, expressed as a {{jsxref('Temporal.PlainDateTime','Temporal.PlainDateTime')}} object, or else a value convertible to one.</p>
-</dd>
 <div class="warning">
-<strong>NOTE:</strong> If either <code>largestUnit</code> or <code>smallestUnit</code> is <code>'years'</code>, <code>'months'</code>, or <code>'weeks'</code>, or if the base duration has nonzero value for any of years, months, or weeks, then the <code>relativeTo</code> option is <strong>required</strong>.
+<p><strong>Warning:</strong> If either <code>largestUnit</code> or <code>smallestUnit</code> is <code>'years'</code>, <code>'months'</code>, or <code>'weeks'</code>, or if the base duration has nonzero value for any of years, months, or weeks, then the <code>relativeTo</code> option is <strong>required</strong>.</p>
 </div>
+</dd>
 <dt><code>roundingIncrement</code> {{ optional_inline }}</dt>
 <dd><p>An integer defining the granularity of the rounding of the unit given by <code>smallestUnit</code>. The default is <code>1</code>.  This value must divide evenly into the next highest unit after <code>smallestUnit</code>, and must not be equal to it. For example, if <code>smallestUnit</code> is <code>'minutes'</code>, then the number of minutes given by <code>roundingIncrement</code> must divide evenly into 60 minutes, which is one hour. The valid values in this case are 1 (default), 2, 3, 4, 5, 6, 10, 12, 15, 20, and 30. Instead of 60 minutes, use 1 hour.)</p></dd>
 <dt><code>roundingMode</code> {{ optional_inline }}</dt>

--- a/files/en-us/web/javascript/reference/global_objects/temporal/instant/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/instant/tolocalestring/index.html
@@ -83,8 +83,6 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 					<li>"<code>medium</code>"</li>
 					<li>"<code>short</code>"</li>
 				</ul>
-			</dd>
-			<dd>
 				<div class="notecard note">
 					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindate/tolocalestring/index.html
@@ -85,8 +85,6 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 					<li>"<code>medium</code>"</li>
 					<li>"<code>short</code>"</li>
 				</ul>
-			</dd>
-			<dd>
 				<div class="notecard note">
 					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaindatetime/tolocalestring/index.html
@@ -85,8 +85,6 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 					<li>"<code>medium</code>"</li>
 					<li>"<code>short</code>"</li>
 				</ul>
-			</dd>
-			<dd>
 				<div class="notecard note">
 					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainmonthday/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainmonthday/tolocalestring/index.html
@@ -86,8 +86,6 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 					<li>"<code>medium</code>"</li>
 					<li>"<code>short</code>"</li>
 				</ul>
-			</dd>
-			<dd>
 				<div class="notecard note">
 					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plaintime/tolocalestring/index.html
@@ -85,8 +85,6 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 					<li>"<code>medium</code>"</li>
 					<li>"<code>short</code>"</li>
 				</ul>
-			</dd>
-			<dd>
 				<div class="notecard note">
 					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,

--- a/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/plainyearmonth/tolocalestring/index.html
@@ -86,8 +86,6 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 					<li>"<code>medium</code>"</li>
 					<li>"<code>short</code>"</li>
 				</ul>
-			</dd>
-			<dd>
 				<div class="notecard note">
 					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,

--- a/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/tolocalestring/index.html
+++ b/files/en-us/web/javascript/reference/global_objects/temporal/zoneddatetime/tolocalestring/index.html
@@ -85,10 +85,8 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 					<li>"<code>medium</code>"</li>
 					<li>"<code>short</code>"</li>
 				</ul>
-			</dd>
-			<dd>
 				<div class="notecard note">
-					<p><code>timeStyle</code> can be used with <code>dateStyle</code>, but
+					<p><strong>Note:</strong> <code>timeStyle</code> can be used with <code>dateStyle</code>, but
 						not with other options (e.g. <code>weekday</code>,
 						<code>hour</code>, <code>month</code>, etc.).</p>
 				</div>
@@ -125,7 +123,7 @@ toLocaleString(<var>locales</var>, <var>options</var>)
 				such as "<code>Asia/Shanghai</code>", "<code>Asia/Kolkata</code>",
 				"<code>America/New_York</code>".
 				<div class="warning">
-				<code>timeZone</code> will be automatically set from the time zone of the <code>zonedDateTime</code> object. If a different time zone ID is provided in the <code>timeZone</code> option, a <code>RangeError</code> will be thrown. To display a {{jsxref('Temporal.ZonedDateTime','Temporal.ZonedDateTime')}} value in a different time zone, use <code>{{jsxref('Temporal.ZonedDateTime/withTimeZone','Temporal.ZonedDateTime.withTimeZone(<var>otherTimeZone</var>)')}}.toLocaleString()</code>.
+				<p><strong>Warning:</strong> <code>timeZone</code> will be automatically set from the time zone of the <code>zonedDateTime</code> object. If a different time zone ID is provided in the <code>timeZone</code> option, a <code>RangeError</code> will be thrown. To display a {{jsxref('Temporal.ZonedDateTime','Temporal.ZonedDateTime')}} value in a different time zone, use <code>{{jsxref('Temporal.ZonedDateTime/withTimeZone','Temporal.ZonedDateTime.withTimeZone(<var>otherTimeZone</var>)')}}.toLocaleString()</code>.</p>
 				</div>
 				</dd>
 			<dt><code>hour12</code></dt>


### PR DESCRIPTION
This PR fixes the unconvertible `<dl>` elements in the Temporal docs.

There were 8 of these:
* one was because some `<div>` elements were at the top-level of the `<dl>`, instead of being under the `<dd>`. I moved them inside the `<dd>`.
* the rest were because of some consecutive `<dd>` elements: although this is allowed in `<dl>` it's not supported in our Markdown `<dl>` syntax, and is (almost?) never needed in MDN. In these cases I don't think it was needed, so I merged them.

I also fixed a few notes and warnings that weren't being logged as unconvertible (because they were inside a `<dl>` that wasn't being converted).
