### PR TITLE
SVG stroke review

### DIFF
--- a/files/en-us/web/css/stroke-dasharray/index.md
+++ b/files/en-us/web/css/stroke-dasharray/index.md
@@ -7,12 +7,17 @@ browser-compat: css.properties.stroke-dasharray
 
 {{CSSRef}}
 
-The **`stroke-dasharray`** [CSS](/en-US/docs/Web/CSS) property defines a pattern of dashes and gaps used in the painting of a shape's stroke. It applies to any SVG shape or text-content element (see {{SVGAttr("stroke-dasharray")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
+The **`stroke-dasharray`** [CSS](/en-US/docs/Web/CSS) property defines a pattern of dashes and gaps used in the painting of the [SVG](/en-US/docs/Web/SVG) shape's stroke. If present, it overrides the element's {{SVGAttr("stroke-dasharray")}} attribute.
+
+This property applies to any SVG shape or text-content element (see {{SVGAttr("stroke-dasharray")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
 
 ## Syntax
 
 ```css
+/* Keywords */
 stroke-dasharray: none;
+
+/* Numeric, length, and percentage values */
 stroke-dasharray: 2px, 5px;
 stroke-dasharray: 20%, 50%;
 stroke-dasharray: 2, 5;
@@ -31,17 +36,23 @@ stroke-dasharray: unset;
 
 ### Values
 
+The value is a list of comma and/or white space separated `<number>`, `<length>`, and / or `<percentage>` values that specify the lengths of alternating dashes and gaps, or the keyword `none`. If an odd number of values are given, the entire value will be repeated in order to set an even number of values.
+
 - `none`
 
   - : The stroke will be drawn without any dashes. The default value.
 
 - {{cssxref("&lt;number&gt;")}}
 
-  - : A number of SVG units, the size of which defined by the current unit space. The value given, if other than `0`, moves the starting point from the start of the dash array to another point within it. If an odd number of values are given, the entire value will be repeated in order to set an even number of values. Negative values are invalid.
+  - : A number of SVG units, the size of which defined by the current unit space. The value given, if other than `0`, moves the starting point from the start of the dash array to another point within it. Negative values are invalid.
 
-- {{cssxref("&lt;length-percentage&gt;")}}
+- {{cssxref("&lt;length&gt;")}}
 
-  - : Pixel units are handled the same as SVG units (see `<number>`, above) and font-based lengths such as `em` are calculated with repect to the element's SVG value for the text size; the effects of other length units may depend on the browser. Percentages are defined to be calculated as a percentage of the current SVG viewport. If an odd number of values are given, the entire value will be repeated in order to set an even number of values. Negative values are invalid.
+  - : Pixel units are handled the same as SVG units (see `<number>`, above) and font-based lengths such as `em` are calculated with repect to the element's SVG value for the text size; the effects of other length units may depend on the browser. Negative values are invalid.
+
+- {{cssxref("&lt;percentage&gt;")}}
+
+  - : Percentages refer to the normalized diagonal of the current SVG viewport, which is calculated as <math><mfrac><msqrt><mrow><msup><mi>&lt;width&gt;</mi><mn>2</mn></msup><mo>+</mo><msup><mi>&lt;height&gt;</mi><mn>2</mn></msup></mrow></msqrt><msqrt><mn>2</mn></msqrt></mfrac></math>. Negative values are invalid.
 
 ## Formal definition
 
@@ -54,6 +65,10 @@ stroke-dasharray: unset;
 ## Examples
 
 ### Basic dash array
+
+This example demonstrates basic usage of the `stroke-dasharray` property using space-separated `<number>` values.
+
+#### HTML
 
 First, we set up a basic SVG rectangle shape. To this rectangle, a red stroke with a width of `2` is applied.
 
@@ -70,19 +85,27 @@ First, we set up a basic SVG rectangle shape. To this rectangle, a red stroke wi
 </svg>
 ```
 
-Via CSS, we define a dash pattern for the stroke: six units of dash, followed by six units of space. This means the gaps between dashes will be the same length as the dashes themselves.
+#### CSS
+
+We define a dash pattern for the stroke: ten units of dash, followed by five units of space. This means the gaps between dashes will be half the length as the dashes themselves.
 
 ```css
 rect {
-  stroke-dasharray: 6, 6;
+  stroke-dasharray: 10 5;
 }
 ```
 
-Where the stroke turns a corner, the pattern is carried along, as it were. At the top left corner, where the start and end of the stroke meet, the six-unit-long starting dash appears to join with the part of the dash pattern seen at the end of the path, creating what looks like a longer-than-six-units line bending around the corner.
+#### Results
 
 {{EmbedLiveSample("Basic dash array", "500", "250")}}
 
+Where the stroke turns a corner, the pattern is carried along, as it were. At the top left corner, where the start and end of the stroke meet, the ten-unit-long starting dash appears to join with the part of the dash pattern seen at the end of the path, creating what looks like a longer-than-ten-units line bending around the corner.
+
 ### Dash array repetition
+
+This example includes an odd-number of comma-separated `<number>` values to demonstrates how the value is repeated if an odd number of values is given in order to set an even number of values.
+
+#### html
 
 In this case, we define two rectangles.
 
@@ -107,7 +130,9 @@ In this case, we define two rectangles.
 </svg>
 ```
 
-To the first rectangle, we define a dasharray of `5,5,1`, which calls for five units of dash, five of gap, and one unit of dash. However, because this is an odd number of numbers, the entire set of numbers is repeated, thus creating a value identical to that applied to the second rectangle.
+#### CSS
+
+To the first rectangle, we define a dasharray of `5, 5, 1`, which calls for five units of dash, five of gap, and one unit of dash. However, because this is an odd number of numbers, the entire set of numbers is repeated, thus creating a value identical to that applied to the second rectangle.
 
 ```css
 rect:nth-of-type(1) {
@@ -118,11 +143,17 @@ rect:nth-of-type(2) {
 }
 ```
 
-The reason an even count of numbers is required is so that every dash array begins with a dash and ends with a gap. Thus, the pattern defined is a five-unit dash, a five-unit gap, a one-unit dash, a five-unit gap, a five-unit dash, and a one-unit gap. In the resulting stroke, every instance of a one-unit gap between two five-unit dashes indicates a place where the dash array starts over.
+#### Result
 
 {{EmbedLiveSample("Dash array repetition", "500", "500")}}
 
+The reason an even count of numbers is required is so that every dash array begins with a dash and ends with a gap. Thus, the pattern defined is a five-unit dash, a five-unit gap, a one-unit dash, a five-unit gap, a five-unit dash, and a one-unit gap. In the resulting stroke, every instance of a one-unit gap between two five-unit dashes indicates a place where the dash array starts over.
+
 ### Percentage and pixel values
+
+This example demonstrates the use of `<percentage>` and `<length>` values within the `stroke-dasharray` property value.
+
+#### HTML
 
 As in the previous example, we define two rectangles.
 
@@ -147,6 +178,8 @@ As in the previous example, we define two rectangles.
 </svg>
 ```
 
+#### CSS
+
 This time, rather than collections of bare numbers, we use pixel units and percentages.
 
 ```css
@@ -158,9 +191,11 @@ rect:nth-of-type(2) {
 }
 ```
 
-The results are essentially indistinguishable from the results in the previous example.
+#### Results
 
 {{EmbedLiveSample("Percentage and pixel values", "500", "500")}}
+
+The results are essentially indistinguishable from the results in the previous example.
 
 ## Specifications
 
@@ -172,6 +207,11 @@ The results are essentially indistinguishable from the results in the previous e
 
 ## See also
 
+- {{cssxref("stroke-dashoffset")}}
+- {{cssxref("stroke-linecap")}}
+- {{cssxref("stroke-linejoin")}}
+- {{cssxref("stroke-miterlimit")}}
+- {{cssxref("stroke-opacity")}}
+- {{cssxref("stroke-width")}}
+- {{cssxref("stroke")}}
 - SVG {{SVGAttr("stroke-dasharray")}} attribute
-- CSS {{CSSxref("stroke-dashoffset")}} property
-- CSS {{CSSxref("stroke")}} property

--- a/files/en-us/web/css/stroke-dashoffset/index.md
+++ b/files/en-us/web/css/stroke-dashoffset/index.md
@@ -7,15 +7,20 @@ browser-compat: css.properties.stroke-dashoffset
 
 {{CSSRef}}
 
-The **`stroke-dashoffset`** [CSS](/en-US/docs/Web/CSS) property defined an offset for the starting point of the rendering of the associated dash array. It applies to any SVG shape or text-content element (see {{SVGAttr("stroke-dashoffset")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
+The **`stroke-dashoffset`** [CSS](/en-US/docs/Web/CSS) property defines an offset for the starting point of the rendering of an [SVG](/en-US/docs/Web/SVG) element's associated {{CSSxref("stroke-dasharray", "dash array")}}. If present, it overrides the element's {{SVGAttr("stroke-dashoffset")}} attribute.
+
+This property applies to any SVG shape or text-content element (see {{SVGAttr("stroke-dashoffset")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
 
 ## Syntax
 
 ```css
+/* Keyword */
 stroke-dashoffset: none;
+
+/* Length and percentage values */
+stroke-dashoffset: 2;
 stroke-dashoffset: 2px;
 stroke-dashoffset: 2%;
-stroke-dashoffset: 2;
 
 /* Global values */
 stroke-dashoffset: inherit;
@@ -27,7 +32,7 @@ stroke-dashoffset: unset;
 
 ### Values
 
-- {{cssxref("&lt;number&gt;")}}
+- {{cssxref("&lt;number&gt;")}} {{non-standard_Inline}}
 
   - : A number of SVG units, the size of which defined by the current unit space. The value given, if other than `0`, moves the starting point from the start of the dash array to another point within it. Thus, positive values will appear to shift the dash-gap pattern _backwards_, and negative values will appear to shift the pattern _forwards_.
 

--- a/files/en-us/web/css/stroke-linecap/index.md
+++ b/files/en-us/web/css/stroke-linecap/index.md
@@ -7,7 +7,9 @@ browser-compat: css.properties.stroke-linecap
 
 {{CSSRef}}
 
-The **`stroke-linecap`** [CSS](/en-US/docs/Web/CSS) property defines the shape to be used at the end of open subpaths of strokes. It applies to any SVG shape that can have unclosed strokes and text-content element (see {{SVGAttr("stroke-linecap")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
+The **`stroke-linecap`** [CSS](/en-US/docs/Web/CSS) property defines the shape to be used at the end of open subpaths of [SVG](/en-US/docs/Web/SVG) elements' unclosed strokes. If present, it overrides the element's {{SVGAttr("stroke-linecap")}} attribute.
+
+This property applies to any SVG shape that can have unclosed strokes and text-content element (see {{SVGAttr("stroke-linecap")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
 
 ## Syntax
 
@@ -29,7 +31,7 @@ stroke-linecap: unset;
 
 - `butt`
 
-  - : Indicates that the stroke for each subpath does not extend beyond its two endpoints. On a zero-length subpath, the path will not be rendered at all. The default value.
+  - : Indicates that the stroke for each subpath does not extend beyond its two endpoints. On a zero-length subpath, the path will not be rendered at all. This is the default value.
 
 - `round`
 
@@ -51,7 +53,11 @@ stroke-linecap: unset;
 
 ### Linecaps
 
-To set things up, we first set up a light-gray rectangle. Then, in a group, three paths are defined whose length is exactly the same as the width of the rectangle, and all of which start at the left edge of the rectangle. They are all set to have a dodgerblue stroke with a width of seven.
+This example demonstrates the property's three keyword values
+
+#### HTML
+
+To set things up, we first set up a light-gray rectangle. Then, in a group, three paths are defined whose length is exactly the same as the width of the rectangle, and all of which start at the left edge of the rectangle. They are all set to have a `dodgerblue` stroke with a width of seven.
 
 ```html
 <svg viewBox="0 0 100 50" width="500" height="250">
@@ -64,7 +70,9 @@ To set things up, we first set up a light-gray rectangle. Then, in a group, thre
 </svg>
 ```
 
-We then apply a different linecap style to each path via CSS.
+#### CSS
+
+We apply a different linecap style to each path via CSS.
 
 ```css
 path:nth-of-type(1) {
@@ -78,9 +86,11 @@ path:nth-of-type(3) {
 }
 ```
 
-The first path has `butt` linecaps, which essentially means the stroke will run exactly to the end points (both the start and the end) of the path, and no further. The second path has `square` linecaps, so the visible path extends out past the end points of the path, making the overall length of the path appear to be 87, since the path length is 80 and each of the two square caps is 3.5 wide. The third path has `circle` caps, so while it also appears to be 87 units long, the two caps are semicircular instead of square.
+#### Results
 
 {{EmbedLiveSample("Linecaps", "500", "250")}}
+
+The first path has `butt` linecaps, which essentially means the stroke runs exactly to the end points (both the start and the end) of the path, and no further. The second path has `square` linecaps, so the visible path extends out past the end points of the path, making the overall length of the path appear to be 87, since the path length is 80 and each of the two square caps is 3.5 wide. The third path has `circle` caps, so while it also appears to be 87 units long, the two caps are semicircular instead of square.
 
 ## Specifications
 
@@ -92,5 +102,11 @@ The first path has `butt` linecaps, which essentially means the stroke will run 
 
 ## See also
 
+- {{cssxref("stroke-dasharray")}}
+- {{cssxref("stroke-dashoffset")}}
+- {{cssxref("stroke-linejoin")}}
+- {{cssxref("stroke-miterlimit")}}
+- {{cssxref("stroke-opacity")}}
+- {{cssxref("stroke-width")}}
+- {{cssxref("stroke")}}
 - SVG {{SVGAttr("stroke-linecap")}} attribute
-- CSS {{CSSxref("stroke")}} property

--- a/files/en-us/web/css/stroke-linejoin/index.md
+++ b/files/en-us/web/css/stroke-linejoin/index.md
@@ -7,7 +7,9 @@ browser-compat: css.properties.stroke-linejoin
 
 {{CSSRef}}
 
-The **`stroke-linejoin`** [CSS](/en-US/docs/Web/CSS) property defines the shape to be used at the corners of stroked paths. It applies to any SVG corner-generating shape or text-content element (see {{SVGAttr("stroke-linejoin")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements'
+The **`stroke-linejoin`** [CSS](/en-US/docs/Web/CSS) property defines the shape to be used at the corners of an [SVG](/en-US/docs/Web/SVG) element's stroked paths. If present, it overrides the element's {{SVGAttr("stroke-linejoin")}} attribute.
+
+This property applies to any SVG corner-generating shape or text-content element (see {{SVGAttr("stroke-linejoin")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements'
 
 ## Syntax
 
@@ -27,13 +29,23 @@ stroke-linejoin: unset;
 
 ### Values
 
-- `arcs`
-
-  - : _(Unsupported.)\* Indicates that an \_arcs corner_ is to be used to join path segments. The arc's shape is formed by extending the outer edges of the stroke at the join point with arcs that have the same curvature as the outer edges at the join point.
-
 - `bevel`
 
   - : Indicates that a bevelled corner is to be used to join path segments. The bevel is formed by truncating the corner by a line perpendicular to a line that bisects the difference in the subpath angles where they meet the join point.
+
+- `miter`
+
+  - : Indicates that a sharp corner is to be used to join path segments. The corner is formed by extending the outer edges of the stroke at the tangents of the path segments until they intersect. This is the default value.
+
+- `round`
+
+  - : Indicates that a round corner is to be used to join path segments. This is accomplished by cropping the join as per `bevel`, and then appending a filled arc tangent in order to round the corner.
+
+The following values are defined, but not supported in any browser:
+
+- `arcs`
+
+  - : _(Unsupported.)\* Indicates that an \_arcs corner_ is to be used to join path segments. The arc's shape is formed by extending the outer edges of the stroke at the join point with arcs that have the same curvature as the outer edges at the join point.
 
 - `crop`
 
@@ -42,14 +54,6 @@ stroke-linejoin: unset;
 - `fallback`
 
   - : \_(Unsupported; at risk.)\* behaves identically to `crop bevel` when the {{CSSxref('stroke-miterlimit')}} value is exceeded.
-
-- `miter`
-
-  - : Indicates that a sharp corner is to be used to join path segments. The corner is formed by extending the outer edges of the stroke at the tangents of the path segments until they intersect. The default value.
-
-- `round`
-
-  - : Indicates that a round corner is to be used to join path segments. This is accomplished by cropping the join as per `bevel`, and then appending a filled arc tangent in order to round the corner.
 
 ## Formal definition
 
@@ -63,7 +67,11 @@ stroke-linejoin: unset;
 
 ### Line-joining styles
 
-First, we set up four identical paths, all of which have a black stroke with a width of one and no fill.
+This example demonstrates the three currently supported keyword values for `stroke-linejoin`.
+
+#### HTML
+
+We set up four identical paths, all of which have a black stroke with a width of one and no fill.
 
 ```html
 <svg viewBox="0 0 15 12" xmlns="http://www.w3.org/2000/svg">
@@ -75,6 +83,8 @@ First, we set up four identical paths, all of which have a black stroke with a w
   </g>
 </svg>
 ```
+
+#### CSS
 
 To each of the four paths, a supported line-joining value is applied. The first is beveled, the second rounded, the third mitered, and the fourth also mitered but with a {{CSSxref('stroke-miterlimit')}} of `2`, which forces the corner to be beveled instead of mitered.
 
@@ -94,6 +104,8 @@ path:nth-child(4) {
 }
 ```
 
+#### Results
+
 {{EmbedLiveSample("Line-joining styles", "500", "600")}}
 
 ## Specifications
@@ -106,6 +118,11 @@ path:nth-child(4) {
 
 ## See also
 
+- {{cssxref("stroke-dasharray")}}
+- {{cssxref("stroke-dashoffset")}}
+- {{cssxref("stroke-linecap")}}
+- {{cssxref("stroke-miterlimit")}}
+- {{cssxref("stroke-opacity")}}
+- {{cssxref("stroke-width")}}
+- {{cssxref("stroke")}}
 - SVG {{SVGAttr("stroke-linejoin")}} attribute
-- CSS {{CSSxref("stroke-miterlimit")}} property
-- CSS {{CSSxref("stroke")}} property

--- a/files/en-us/web/css/stroke-miterlimit/index.md
+++ b/files/en-us/web/css/stroke-miterlimit/index.md
@@ -7,11 +7,13 @@ browser-compat: css.properties.stroke-miterlimit
 
 {{CSSRef}}
 
-The **`stroke-miterlimit`** [CSS](/en-US/docs/Web/CSS) property defines a limit on the ratio of the miter length to the {{CSSxref("stroke-width") }} when drawing a mitered join. If the limit is exceeded, the join is converted from a miter to a bevel, thus making the corner appear truncated. It applies to any SVG corner-generating shape or text-content element (see {{SVGAttr("stroke-miterlimit")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
+The **`stroke-miterlimit`** [CSS](/en-US/docs/Web/CSS) property defines a limit on the ratio of the miter length to the {{CSSxref("stroke-width") }} when the shape to be used at the corners of an [SVG](/en-US/docs/Web/SVG) element's stroked path is a mitered join. If the limit defined by this property is exceeded, the join is converted from `miter` to `bevel`, thus making the corner appear truncated.
+
+This property applies to any SVG corner-generating shape or text-content element (see {{SVGAttr("stroke-miterlimit")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes. If present, it overrides the element's {{SVGAttr("stroke-miterjoin")}} attribute.
 
 ## Description
 
-When two line segments meet at a sharp angle and `miter` joins have been specified for {{ CSSxref("stroke-linejoin") }}, it is possible for the miter to extend far beyond the thickness of the line stroking the path. The `stroke-miterlimit` ratio is used to define a limit, past which the join is converted from a miter to a bevel.
+When two line segments meet at a sharp angle and `miter` joins have been specified for {{ CSSxref("stroke-linejoin") }} or default to that value, it is possible for the miter to extend far beyond the thickness of the line stroking the path. The `stroke-miterlimit` ratio is used to define a limit, past which the join is converted from a miter to a bevel.
 
 The ratio of miter length (the distance between the outer tip and the inner corner of the miter) to {{ CSSxref("stroke-width") }} is directly related to the angle (theta) between the segments in user space by the formula:
 
@@ -21,7 +23,7 @@ The ratio of miter length (the distance between the outer tip and the inner corn
 </math>
 <!-- prettier-ignore-end -->
 
-For example, a miter limit of 1.414 converts miters to bevels for theta less than 90 degrees, a limit of 4.0 converts them for theta less than approximately 29 degrees, and a limit of 10.0 converts them for theta less than approximately 11.5 degrees.
+For example, a miter limit of `1.414` converts miters to bevels for theta less than 90 degrees, a limit of `4.0` converts them for theta less than approximately 29 degrees, and a limit of `10.0` converts them for theta less than approximately 11.5 degrees.
 
 ## Syntax
 
@@ -42,7 +44,7 @@ stroke-miterlimit: unset;
 
 - {{cssxref("&lt;number&gt;")}}
 
-  - : Any real positive number equal to or greater than 1; values below that are invalid.
+  - : Any real positive number equal to or greater than `1`; values below that are invalid. The initial value is `4`.
 
 ## Formal definition
 
@@ -56,7 +58,11 @@ stroke-miterlimit: unset;
 
 ### Various miter limits
 
-First, we set up five multi-segment paths, all of which use a black stroke with a width of one, and no fill. Each path creates a series of mountain symbols, going from left (a shallow corner angle) to right (an extreme corner angle).
+This example demonstrates the effect of different values for the `stroke-miterlimit` property.
+
+#### HTML
+
+We set up five multi-segment paths, all of which use a black stroke with a width of one, and no fill. Each path creates a series of mountain symbols, going from left (a shallow corner angle) to right (an extreme corner angle).
 
 ```html
 <svg viewBox="0 0 39 36" xmlns="http://www.w3.org/2000/svg">
@@ -79,7 +85,9 @@ First, we set up five multi-segment paths, all of which use a black stroke with 
 </svg>
 ```
 
-To this, we use CSS to apply increasingly large values of `stroke-miterlimit` to the paths, such that for the first path, only the first (leftmost) subpath is mitered; for the second path, the first two subpaths are mitered; and so on until for the fifth path, all five subpaths are mitered.
+#### CSS
+
+We apply increasingly large values of `stroke-miterlimit` to the paths, such that for the first path, only the first (leftmost) subpath is mitered; for the second path, the first two subpaths are mitered; and so on until for the fifth path, all five subpaths are mitered.
 
 ```css
 path:nth-child(1) {
@@ -111,7 +119,11 @@ path:nth-child(5) {
 
 ## See also
 
+- {{cssxref("stroke-dasharray")}}
+- {{cssxref("stroke-dashoffset")}}
+- {{cssxref("stroke-linecap")}}
+- {{cssxref("stroke-linejoin")}}
+- {{cssxref("stroke-opacity")}}
+- {{cssxref("stroke-width")}}
+- {{cssxref("stroke")}}
 - SVG {{SVGAttr("stroke-miterlimit")}} attribute
-- CSS {{CSSxref("stroke-linejoin")}} property
-- CSS {{CSSxref("stroke-width")}} property
-- CSS {{CSSxref("stroke")}} property

--- a/files/en-us/web/css/stroke-opacity/index.md
+++ b/files/en-us/web/css/stroke-opacity/index.md
@@ -7,13 +7,19 @@ browser-compat: css.properties.stroke-opacity
 
 {{CSSRef}}
 
-The **`stroke-opacity`** [CSS](/en-US/docs/Web/CSS) property defines the opacity of a shape's stroke. The effect is identical to that of {{CSSxref('opacity')}}, except it is applied only to the stroke, not to the entire element. It applies to any SVG shape or text-content element (see {{SVGAttr("stroke-opacity")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
+The **`stroke-opacity`** [CSS](/en-US/docs/Web/CSS) property defines the opacity of an [SVG](/en-US/docs/Web/SVG) shape's stroke. The effect is identical to that of {{CSSxref('opacity')}}, except it is applied only to the stroke, not to the entire element. If present, it overrides the element's {{SVGAttr("stroke-opacity")}} attribute.
+
+This property applies to SVG shapes and text-content elements (see {{SVGAttr("stroke-opacity")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes.
+
+Note that a shape's stroke partially covers the fill of that shape, so a stroke with an opacity less than `1` will show the fill blended with the stroke where they overlap. To avoid this effect, it is possible to apply a global opacity with the {{cssxref('opacity')}} property or to put the stroke behind the fill with the {{cssxref('paint-order')}} attribute.
 
 ## Syntax
 
 ```css
-/* number values */
+/* numeric and percentage values */
 stroke-opacity: 1;
+stroke-opacity: 0.3;
+stroke-opacity: 50%;
 
 /* Global values */
 stroke-opacity: inherit;
@@ -27,7 +33,7 @@ stroke-opacity: unset;
 
 - {{cssxref("&lt;number&gt;")}}
 
-  - : Any real number from 0 to 1, inclusive. A value of `0` makes the stroke completely transparent, and a value of `1` makes it completely opaque. Values outside the range 0 – 1 are clipped to the nearest end of that range; thus, negative values are clipped to `0`. Note that a shape's stroke partially covers the fill of that shape, so a stroke with an opacity lower than `1` will show the fill blended with the stroke where the two overlap.
+  - : Any real number from 0 to 1, inclusive. A value of `0` makes the stroke completely transparent, and a value of `1` makes it completely opaque. Values outside the range 0 – 1 are clipped to the nearest end of that range; thus, negative values are clipped to `0`.
 
 - {{cssxref("&lt;percentage&gt;")}}
 
@@ -45,7 +51,11 @@ stroke-opacity: unset;
 
 ### Various stroke opacities
 
-First, we set up five multi-segment paths, all of which use a black stroke with a width of one, and a dodgerblue fill for the subpaths. Each path creates a series of mountain symbols, going from left (a shallow corner angle) to right (an extreme corner angle).
+This example demonstrates basic usage of the `stroke-opacity` property and how, as a shape's stroke partially covers its fill, a stroke with an opacity less than `1` blends with the fill where they overlap.
+
+#### HTML
+
+First, we set up five multi-segment paths, all of which use a black stroke with a width of one, and a `dodgerblue` fill for the subpaths. Each path creates a series of mountain symbols, going from left (a shallow corner angle) to right (an extreme corner angle).
 
 ```html
 <svg viewBox="0 0 39 36" xmlns="http://www.w3.org/2000/svg">
@@ -68,6 +78,8 @@ First, we set up five multi-segment paths, all of which use a black stroke with 
 </svg>
 ```
 
+#### CSS
+
 To these paths, we apply a successively higher stroke opacity value. For the first four paths, the fill can be seen through the inner half of the stroke path, though it may be difficult to discern for the fourth path. For the fifth and last path, the stroke is fully opaque and so the fill cannot be seen through the stroke.
 
 ```css
@@ -88,6 +100,8 @@ g path:nth-child(5) {
 } /* equiv. 100% */
 ```
 
+#### Results
+
 {{EmbedLiveSample("Various stroke opacities", "400", "650")}}
 
 ## Specifications
@@ -100,5 +114,14 @@ g path:nth-child(5) {
 
 ## See also
 
+- {{cssxref('opacity')}}
+- {{cssxref('fill-opacity')}}
+- {{cssxref('paint-order')}}
+- {{cssxref('stroke')}}
+- {{cssxref("stroke-dasharray")}}
+- {{cssxref("stroke-dashoffset")}}
+- {{cssxref("stroke-linecap")}}
+- {{cssxref("stroke-linejoin")}}
+- {{cssxref("stroke-miterlimit")}}
+- {{cssxref("stroke-width")}}
 - SVG {{SVGAttr("stroke-opacity")}} attribute
-- CSS {{CSSxref("stroke")}} property

--- a/files/en-us/web/css/stroke-width/index.md
+++ b/files/en-us/web/css/stroke-width/index.md
@@ -7,14 +7,16 @@ browser-compat: css.properties.stroke-width
 
 {{CSSRef}}
 
-The **`stroke-width`** [CSS](/en-US/docs/Web/CSS) property defines the width of a stroke applied to the shape. It applies to any SVG shape or text-content element (see {{SVGAttr("stroke-width")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes. If the value evaluates to zero, the stroke is not drawn.
+The **`stroke-width`** [CSS](/en-US/docs/Web/CSS) property defines the width of a stroke applied to the [SVG](/en-US/docs/Web/SVG) shape. If present, it overrides the element's {{SVGAttr("stroke-width")}} attribute.
+
+This property applies to any SVG shape or text-content element (see {{SVGAttr("stroke-width")}} for a full list), but as an inherited property, it may be applied to elements such as {{SVGElement("g")}} and still have the intended effect on descendant elements' strokes. If the value evaluates to zero, the stroke is not drawn.
 
 ## Syntax
 
 ```css
-/* number values */
-stroke-width: 0;
-stroke-width: 1.414;
+/* Length and percentage values */
+stroke-width: 0%;
+stroke-width: 1.414px;
 
 /* Global values */
 stroke-width: inherit;
@@ -26,13 +28,17 @@ stroke-width: unset;
 
 ### Values
 
-- {{cssxref("&lt;number&gt;")}}
+- {{cssxref("&lt;length&gt;")}}
+
+  - : Pixel units are handled the same as SVG units (see `<number>`, above) and font-based lengths such as `em` are calculated with repect to the element's SVG value for the text size; the effects of other length units may depend on the browser.
+
+- {{cssxref("&lt;percentage&gt;")}}
+
+  - : Percentages refer to the normalized diagonal of the current SVG viewport, which is calculated as <math><mfrac><msqrt><mrow><msup><mi>&lt;width&gt;</mi><mn>2</mn></msup><mo>+</mo><msup><mi>&lt;height&gt;</mi><mn>2</mn></msup></mrow></msqrt><msqrt><mn>2</mn></msqrt></mfrac></math>.
+
+- {{cssxref("&lt;number&gt;")}} {{non-standard_inline}}
 
   - : A number of SVG units, the size of which defined by the current unit space.
-
-- {{cssxref("&lt;length-percentage&gt;")}}
-
-  - : Pixel units are handled the same as SVG units (see `<number>`, above) and font-based lengths such as `em` are calculated with repect to the element's SVG value for the text size; the effects of other length units may depend on the browser. Percentages are defined to be calculated as a percentage of the current SVG viewport's diagonal measure.
 
 ## Formal definition
 
@@ -45,6 +51,10 @@ stroke-width: unset;
 ## Examples
 
 ### Various stroke widths
+
+This example demonstrates various value syntaxes for the `stroke-width` property.
+
+#### HTML
 
 First, we set up five multi-segment paths, all of which use a black stroke with a width of one, and no fill. Each path creates a series of mountain symbols, going from left (a shallow corner angle) to right (an extreme corner angle).
 
@@ -69,6 +79,8 @@ First, we set up five multi-segment paths, all of which use a black stroke with 
 </svg>
 ```
 
+#### CSS
+
 To the first four paths, we apply stroke width values as pairs to show how bare number values and pixel values are functionally equivalent. For the first two paths, the values are `.25` and `.25px`. For the second two paths, the values are `1` and `1px`.
 
 For the fifth and last path, a value of `5%` is applied, thus setting a stroke width that is five percent as wide as the SVG viewport's diagonal measure is long.
@@ -91,6 +103,8 @@ path:nth-child(5) {
 }
 ```
 
+#### Results
+
 {{EmbedLiveSample("Various stroke widths", "400", "540")}}
 
 ## Specifications
@@ -103,5 +117,12 @@ path:nth-child(5) {
 
 ## See also
 
+- {{CSSxref("stroke")}}
+- {{cssxref("stroke-dasharray")}}
+- {{cssxref("stroke-dashoffset")}}
+- {{cssxref("stroke-linecap")}}
+- {{cssxref("stroke-linejoin")}}
+- {{cssxref("stroke-miterlimit")}}
+- {{cssxref("stroke-opacity")}}
+- {{CSSxref("fill")}}
 - SVG {{SVGAttr("stroke-width")}} attribute
-- CSS {{CSSxref("stroke")}} property

--- a/files/en-us/web/svg/attribute/stroke-opacity/index.md
+++ b/files/en-us/web/svg/attribute/stroke-opacity/index.md
@@ -80,9 +80,6 @@ svg {
   </tbody>
 </table>
 
-> [!NOTE]
-> SVG2 introduces percentage values for `stroke-opacity`, however, it is not widely supported yet (_See [Browser compatibility](#browser_compatibility) below_) as a consequence, it is best practices to set opacity with a value in the range `[0-1]`.
-
 It's important to know that the stroke partially covers the fill of a shape, so a stroke with an opacity different than `1` will partially show the fill underneath. To avoid this effect, it is possible to apply a global opacity with the {{SVGAttr('opacity')}} attribute or to put the stroke behind the fill with the {{SVGAttr('paint-order')}} attribute.
 
 ## Specifications
@@ -95,6 +92,16 @@ It's important to know that the stroke partially covers the fill of a shape, so 
 
 ## See also
 
+CSS properties:
+
+- {{cssxref('stroke-opacity')}}
+- {{cssxref('stroke')}}
+- {{cssxref('opacity')}}
+- {{cssxref('fill-opacity')}}
+
+SVG Attributes:
+
+- {{SVGAttr("stroke")}}
 - {{SVGAttr("opacity")}}
 - {{SVGAttr("fill-opacity")}}
 - {{SVGAttr("stop-opacity")}}


### PR DESCRIPTION
I made a bunch of suggested changes, and figured this was an easier way to suggest them. It was an excellent read and i learned a lot.

* All examples: 
     * add intro sentence, 
     * html, css, and results headings, 
     * moving description of results to after the example is shown
     * Optional (I didn't do this edit) you can remove the xmlns from the last four docs (it's not in the examples in the first 3)
* Intro paragraphs:
    * added SVG mention with a link to SVG page.
    * added that the property overrides the attribute
    * paragraph break between intro sentence and the inheritance sentence.
* Syntax:
    * separated out keywords (if any) from other values
    * in one spec i read some did not support numbers, in others they did support number, but i had already removed number (no unit) hence the order change in some cases
    * added headers to the sections (i.e. "Numeric, length, and percentage values" and "Keyword values"
* Values
    * added a summary paragraph in some cases 
    * separated length and percentage in all cases
    * added the percent equation (see the `r` property)
    * changed "The default value" to "This is the default value." to match other pages
* See also
    * Included all the stroke-* properties.
    * only included prefix and suffix if the link was not a css property

In `linejoin`, the spec indicates a two-value syntax, but browsers aren't supporting that. I separated the values section into two chunks: supported and not supported. i have seen this done before, but I can't seem to find it and need to call it a day.

in `dasharray`, i change the example from 6, 6 to 10 5 to so people get a sense that the first value is the line and the second is the gap.